### PR TITLE
registerBuiltinFunction() をhsファイル側にも記述できるようにしました

### DIFF
--- a/hidescript/hidescript.ts
+++ b/hidescript/hidescript.ts
@@ -762,7 +762,20 @@ function builtinFunction(pos: number, mode: number): string {
 function variableOrFunctionCall(mode: number): string {
     var pos = searchIdent(ident);
     if (pos < 0) {
-        syntaxError(ident + "が見つかりません");
+        if (ident == "registerBuiltinFunction") {
+            nextSym();
+            checkSym(symLParen, "(");
+            var arg1 = stringValue;
+            nextSym();
+            checkSym(symComma, ',');
+            var arg2 = stringValue;
+            registerBuiltinFunction(arg1, arg2);
+            nextSym();
+            checkSym(symRParen, ')');
+            return "0vR// " + ident + " " + arg1 + " " + arg2;
+        } else {
+            syntaxError(ident + "が見つかりません");
+        }
     }
     nextSym();
     var type = wcsmidstr(identsType[pos], 0, 1);


### PR DESCRIPTION
秀スクリプトを作ってくださり、ありがとうございます。
読み書きしやすいTypeScript系コードから
誰の環境でも動く秀丸マクロファイルをトランスパイル生成できるのは素晴らしいです。

使い始めてみて感じたのが、
（registerBuiltinFunction() をhsファイル側にも書きたい）
でした。
秀丸組み込み関数を手早く追加して、マクロを書くサイクルを速くまわしたく感じたためです。

ということで掲題のとおり実装いたしました。
もしよろしければ採用をご検討いただけますと幸いです。